### PR TITLE
Player accepts/refuses invitation endpoint

### DIFF
--- a/server/seeds/01_games.js
+++ b/server/seeds/01_games.js
@@ -2,9 +2,9 @@ const seed = async knex => {
   await knex('game').del();
 
   const games = [
-    'League of Legends',
     'Counter Strike: Global Offensive',
-    'DOTA 2'
+    'DOTA 2',
+    'League of Legends'
   ].map(name => {
     return { name };
   });

--- a/server/src/invitations/invitationsQueries.js
+++ b/server/src/invitations/invitationsQueries.js
@@ -11,8 +11,14 @@ const getInvitationByPlayerAndTeam = (knex, { playerId, teamId }) =>
 const insertInvitation = (knex, { playerId, teamId, origin }) =>
   knex.insert({ playerId, teamId, origin }).into('request');
 
+const updateInvitationState = (knex, { id, state }) =>
+  knex('request')
+    .update({ state })
+    .where({ id });
+
 module.exports = {
   getInvitationById,
   getInvitationByPlayerAndTeam,
-  insertInvitation
+  insertInvitation,
+  updateInvitationState
 };

--- a/server/src/invitations/invitationsQueries.js
+++ b/server/src/invitations/invitationsQueries.js
@@ -3,10 +3,17 @@ const getInvitationById = (knex, id) =>
     .where({ id })
     .first();
 
-const getInvitationByPlayerAndTeam = (knex, { playerId, teamId }) =>
-  knex('request')
-    .where({ playerId, teamId })
-    .first();
+const getInvitationByPlayerAndTeam = (knex, { playerId, teamId, state }) => {
+  const query = knex('request').where({ playerId, teamId });
+
+  if (state) {
+    query.where({ state });
+  }
+
+  query.first();
+
+  return query;
+};
 
 const insertInvitation = (knex, { playerId, teamId, origin }) =>
   knex.insert({ playerId, teamId, origin }).into('request');

--- a/server/src/invitations/invitationsRouter.js
+++ b/server/src/invitations/invitationsRouter.js
@@ -31,20 +31,22 @@ invitationsRouter.post('/', [
   }
 ]);
 
-invitationsRouter.put('/:invitationId', async (req, res, next) => {
-  const { knex } = req.context;
+invitationsRouter.put('/:invitationId', [
+  invitationsValidations.invitationUpdate,
+  async (req, res, next) => {
+    const { knex, invitationData } = req.context;
 
-  try {
-    const invitation = await invitationsServices.updateInvitationState(knex, {
-      invitationId: req.params.invitationId,
-      playerId: req.user.id,
-      state: req.body.state
-    });
+    try {
+      const invitation = await invitationsServices.updateInvitationState(
+        knex,
+        invitationData
+      );
 
-    return res.data(null, { invitation });
-  } catch (e) {
-    return next(e);
+      return res.data(null, { invitation });
+    } catch (e) {
+      return next(e);
+    }
   }
-});
+]);
 
 module.exports = invitationsRouter;

--- a/server/src/invitations/invitationsRouter.js
+++ b/server/src/invitations/invitationsRouter.js
@@ -31,4 +31,20 @@ invitationsRouter.post('/', [
   }
 ]);
 
+invitationsRouter.put('/:invitationId', async (req, res, next) => {
+  const { knex } = req.context;
+
+  try {
+    const invitation = await invitationsServices.updateInvitationState(knex, {
+      invitationId: req.params.invitationId,
+      playerId: req.user.id,
+      state: req.body.state
+    });
+
+    return res.data(null, { invitation });
+  } catch (e) {
+    return next(e);
+  }
+});
+
 module.exports = invitationsRouter;

--- a/server/src/invitations/invitationsRouter.js
+++ b/server/src/invitations/invitationsRouter.js
@@ -44,6 +44,14 @@ invitationsRouter.put('/:invitationId', [
 
       return res.data(null, { invitation });
     } catch (e) {
+      if (
+        e.name === 'ForbiddenInvitation' ||
+        e.name === 'InvitationAlreadyUpdated'
+      ) {
+        const forbiddenError = new httpErrors(403, e.message);
+        next(forbiddenError);
+      }
+
       return next(e);
     }
   }

--- a/server/src/invitations/invitationsServices.js
+++ b/server/src/invitations/invitationsServices.js
@@ -57,11 +57,16 @@ const invitePlayerToTeam = async (knex, { username, teamId }) => {
 const updateInvitationState = async (knex, { id, playerId, state }) => {
   const invitationData = await invitationsQueries.getInvitationById(knex, id);
 
-  if (
-    invitationData.playerId !== playerId ||
-    invitationData.state !== 'pending'
-  ) {
-    throw new Error('Invitation could not be updated.');
+  if (invitationData.playerId !== playerId) {
+    const error = new Error('The invitation does not belong to the user.');
+    error.name = 'ForbiddenInvitation';
+    throw error;
+  }
+
+  if (invitationData.state !== 'pending') {
+    const error = new Error('The invitation has already been updated.');
+    error.name = 'InvitationAlreadyUpdated';
+    throw error;
   }
 
   await invitationsQueries.updateInvitationState(knex, {

--- a/server/src/invitations/invitationsServices.js
+++ b/server/src/invitations/invitationsServices.js
@@ -56,7 +56,7 @@ const invitePlayerToTeam = async (knex, { username, teamId }) => {
 
 const updateInvitationState = async (knex, { id, playerId, state }) => {
   const updatedInvitationData = await knex.transaction(async trx => {
-    const invitationData = await invitationsQueries.getInvitationById(knex, id);
+    const invitationData = await invitationsQueries.getInvitationById(trx, id);
 
     if (invitationData.playerId !== playerId) {
       const error = new Error('The invitation does not belong to the user.');
@@ -70,18 +70,18 @@ const updateInvitationState = async (knex, { id, playerId, state }) => {
       throw error;
     }
 
-    await invitationsQueries.updateInvitationState(knex, {
+    await invitationsQueries.updateInvitationState(trx, {
       id,
       state
     });
 
     const updatedInvitationData = await invitationsQueries.getInvitationById(
-      knex,
+      trx,
       id
     );
 
     if (updatedInvitationData.state === 'accepted') {
-      await addPlayerToTeam(knex, {
+      await addPlayerToTeam(trx, {
         playerId: updatedInvitationData.playerId,
         teamId: updatedInvitationData.teamId
       });

--- a/server/src/invitations/invitationsServices.js
+++ b/server/src/invitations/invitationsServices.js
@@ -25,7 +25,7 @@ const invitePlayerToTeam = async (knex, { username, teamId }) => {
 
   const existingInvitation = await invitationsQueries.getInvitationByPlayerAndTeam(
     knex,
-    { playerId: playerData.id, teamId }
+    { playerId: playerData.id, teamId, state: 'pending' }
   );
 
   if (existingInvitation) {

--- a/server/src/invitations/invitationsServices.js
+++ b/server/src/invitations/invitationsServices.js
@@ -54,14 +54,8 @@ const invitePlayerToTeam = async (knex, { username, teamId }) => {
   return invitationData;
 };
 
-const updateInvitationState = async (
-  knex,
-  { invitationId, playerId, state }
-) => {
-  const invitationData = await invitationsQueries.getInvitationById(
-    knex,
-    invitationId
-  );
+const updateInvitationState = async (knex, { id, playerId, state }) => {
+  const invitationData = await invitationsQueries.getInvitationById(knex, id);
 
   if (
     invitationData.playerId !== playerId ||
@@ -71,13 +65,13 @@ const updateInvitationState = async (
   }
 
   await invitationsQueries.updateInvitationState(knex, {
-    id: invitationId,
+    id,
     state
   });
 
   const updatedInvitationData = await invitationsQueries.getInvitationById(
     knex,
-    invitationId
+    id
   );
 
   if (updatedInvitationData.state === 'accepted') {
@@ -86,6 +80,8 @@ const updateInvitationState = async (
       teamId: updatedInvitationData.teamId
     });
   }
+
+  return updatedInvitationData;
 };
 
 module.exports = { invitePlayerToTeam, updateInvitationState };

--- a/server/src/invitations/invitationsValidations.js
+++ b/server/src/invitations/invitationsValidations.js
@@ -39,7 +39,11 @@ const invitationUpdate = [
     const { state } = req.body;
     const { id } = req.user;
 
-    req.context.invitationData = { id: invitationId, state, playerId: id };
+    req.context.invitationData = {
+      id: Number(invitationId),
+      state,
+      playerId: id
+    };
 
     next();
   }

--- a/server/src/team/teamServices.js
+++ b/server/src/team/teamServices.js
@@ -13,14 +13,7 @@ const registerTeam = async (knex, { name, gameId, captainId }) => {
       throw new Error('Team could not be created.');
     }
 
-    const teamRosterId = await teamQueries.insertTeamRoster(trx, {
-      playerId: captainId,
-      teamId
-    });
-
-    if (!teamRosterId) {
-      throw new Error('Player could not be added to the team.');
-    }
+    await addPlayerToTeam(knex, { playerId: captainId, teamId });
 
     const teamData = await teamQueries.getTeamById(trx, teamId);
 
@@ -36,4 +29,17 @@ const registerTeam = async (knex, { name, gameId, captainId }) => {
   return team;
 };
 
-module.exports = { registerTeam };
+const addPlayerToTeam = async (knex, { playerId, teamId }) => {
+  const teamRosterId = await teamQueries.insertTeamRoster(knex, {
+    playerId,
+    teamId
+  });
+
+  if (!teamRosterId) {
+    throw new Error('Player could not be added to the team.');
+  }
+
+  return teamRosterId;
+};
+
+module.exports = { registerTeam, addPlayerToTeam };

--- a/server/src/team/teamServices.js
+++ b/server/src/team/teamServices.js
@@ -13,7 +13,7 @@ const registerTeam = async (knex, { name, gameId, captainId }) => {
       throw new Error('Team could not be created.');
     }
 
-    await addPlayerToTeam(knex, { playerId: captainId, teamId });
+    await addPlayerToTeam(trx, { playerId: captainId, teamId });
 
     const teamData = await teamQueries.getTeamById(trx, teamId);
 


### PR DESCRIPTION
Endpoint: `PUT api/v1/invitations/:invitationId`

Body:
```
{
    "state": "accepted"
}
```

* Endpoint has been implemented for players to accept or refuse team invitations. Valid states are: `accepted` or `refused`.

* When players accept an invitation, they are added to the team roster.

* `addPlayerToTeam` service has been extracted from `registerTeam` service.

This endpoint should work like this:

* Fail if the invitation does not exist.
* Fail if the invitation is not for the same player as the one doing the request.
* Fail if the invitation has already been accepted or refused (only works when state is `pending`).
* Return updated invitation if everything else works and state is `refused`.
* Return updated invitation if everything else works and state is `accepted` AND insert player in `team_roster` table.